### PR TITLE
消费者线程出现问题；

### DIFF
--- a/src/main/java/com/github/hcsp/Executor.java
+++ b/src/main/java/com/github/hcsp/Executor.java
@@ -55,7 +55,6 @@ public class Executor {
                         consumer.accept(future.get());
                     } catch (Exception e) {
                         exceptionInConsumerThread.set(e);
-                        break;
                     }
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -65,6 +64,7 @@ public class Executor {
 
         consumerThread.start();
 
+        //这一块是生产者线程的代码块，使用了线程池，且多线并行的方法
         ExecutorService threadPool = Executors.newCachedThreadPool();
         for (Callable<T> task : tasks) {
             queue.put(threadPool.submit(task));


### PR DESCRIPTION
定位到消费者线程，遇到异常则break，应去掉break，在遇到poisonpill时break；
1.这个方法的运行流程是先启动一个consumer消费者线程，只有一个，他用poll方法进行消费，然后用线程池，启动生产者方法，线程池中放入定义好的callabe接口的方法，因为线程池是用newCachedThreadPool生成的，不够时会自动添加线程，所以生产者有三个线程；
但是Blockingqueue只有两个容量，所以就是当队列为空时，消费者无法消费，等着三个生产者线程中的某一个放入之后，才能进行消费，且由于是linedblockingqueue，所以消费者消费的顺序是放入的顺序；
消费者消费完生产者的内容后，会遇到poisonpill,此时consumerThread.join;然后threadPool.shutDown；
2.会卡死的原因是，因为main方法中的第二个例子中，消费者的消费方法是抛出一个异常，而在原先的方法中，遇到异常则break，消费者的线程已经终止了，由于没有消费者，queue始终是满的，没有办法再放入，所以当再向queue放入poison.pill之类时，会卡死；
3.posionPill是代表者现在应该终止消费者了，当消费者遇到这个时，因为是顺序消费，生产者已经生产完了，消费者也消费完了，应该结束了。


<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

