### PR TITLE
BlockingQueue 容量不足时堵塞

### DIFF
--- a/src/main/java/com/github/hcsp/Executor.java
+++ b/src/main/java/com/github/hcsp/Executor.java
@@ -38,11 +38,14 @@ public class Executor {
     // 2. 为什么有的时候会卡死？应该如何修复？
     // 3. PoisonPill是什么东西？如果不懂的话可以搜索一下。
     public static <T> void runInParallelButConsumeInSerial(List<Callable<T>> tasks,
-                                                            Consumer<T> consumer,
-                                                            int numberOfThreads) throws Exception {
+                                                           Consumer<T> consumer,
+                                                           int numberOfThreads) throws Exception {
+        // 解决方法1： 扩大容量
+//        BlockingQueue<Future<T>> queue = new LinkedBlockingQueue<>(tasks.size());
         BlockingQueue<Future<T>> queue = new LinkedBlockingQueue<>(numberOfThreads);
         AtomicReference<Exception> exceptionInConsumerThread = new AtomicReference<>();
 
+        // 消费
         Thread consumerThread = new Thread(() -> {
             while (true) {
                 try {
@@ -55,7 +58,8 @@ public class Executor {
                         consumer.accept(future.get());
                     } catch (Exception e) {
                         exceptionInConsumerThread.set(e);
-                        break;
+                        //解决方法2：如果抛出异常，不停止消费
+//                        break;
                     }
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -65,6 +69,7 @@ public class Executor {
 
         consumerThread.start();
 
+        // 生产
         ExecutorService threadPool = Executors.newCachedThreadPool();
         for (Callable<T> task : tasks) {
             queue.put(threadPool.submit(task));


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

## 问题
### 1. 这个方法运行的流程是怎么样的？运行的时候JVM中有几个线程？它们如何互相交互？
+ consumerThread： 消费者线程，死循环不断轮训BlockingQueue,每次读取queue中的头部元素
    + 如果读取到 PoisonPill.INSTANCE 意味着消费完毕，结束轮训
    + 否则通过Consumer.accept 消费它，该过程中如果捕获到异常，结束轮训
+ main: 主线程通过创建线程池，读取 tasks里的 任务列表，遍历并创建Thread去执行每一项任务(task)
    + tasks里的任务全部执行完，再往queue里放入一个 PoisonPill.INSTANCE，目的是为了通知轮训可以停止了

运行原理：线程池不断往队列里放任务结果，消费者线程不断一个个读取任务结果并从队列里删除
### 2. 为什么有的时候会卡死？应该如何修复？
队列是有容量限制的，初始化队列时指定容量，当队列没有足够的容量时，再往队里里塞，就会导致队列阻塞。
正常情况下，生产和消费都正常运行，不会导致容量不够，但本例中
```java
try {
    consumer.accept(future.get());
} catch (Exception e) {
    exceptionInConsumerThread.set(e);
    break;
}
```
如果任务结果是一个异常，会导致消费停止，后续只生产不消费，队列就会阻塞
修复方案我尝试了两种方法：
+ 1 任务结果是异常时，只打印异常，不停止轮训
```java
try {
    consumer.accept(future.get());
} catch (Exception e) {
    exceptionInConsumerThread.set(e);
}
```
+ 2 给足够的容量
```java
BlockingQueue<Future<T>> queue = new LinkedBlockingQueue<>(tasks.size());
```
### 3. PoisonPill是什么东西？如果不懂的话可以搜索一下