### PR TITLE
解决死锁问题

### DIFF
--- a/src/main/java/com/github/hcsp/Executor.java
+++ b/src/main/java/com/github/hcsp/Executor.java
@@ -35,8 +35,17 @@ public class Executor {
     // 任务执行期间若抛出任何异常，则在主线程中重新抛出它
     // 请回答：
     // 1. 这个方法运行的流程是怎么样的？运行的时候JVM中有几个线程？它们如何互相交互？
+    // 1.1 主线程创建生产线程池与消费线程,并创建共有对象BlockingQueue,让不同线程之间进行数据交互;
+    // 1.2 3个以上,一个主线程,一个消费线程和一个生产线程池;
+    // 1.3 生产者将数据放入队列中,消费者从队列中取出数据进行消费,当消费者获取到PoisonPill时,消费结束;
+    //     当生产者放完数据,生产结束;
     // 2. 为什么有的时候会卡死？应该如何修复？
+    // 2.1 消费出现异常后,生产者依旧往queue中放数据等待消费,导致队列满了之后,线程阻塞;
+    // 2.2 方法一:记录消费异常,但并不阻止消费中断,继续进行下一个数据的消费;
+    //     方法二:消费异常时,清理queue后,再中断消费线程,避免队列阻塞;
     // 3. PoisonPill是什么东西？如果不懂的话可以搜索一下。
+    // 3.1 在相同进程中,不同线程之间相互影响的状态值;
+    //     在本例中,PoisonPill负责中断消费线程;
     public static <T> void runInParallelButConsumeInSerial(List<Callable<T>> tasks,
                                                             Consumer<T> consumer,
                                                             int numberOfThreads) throws Exception {
@@ -55,7 +64,6 @@ public class Executor {
                         consumer.accept(future.get());
                     } catch (Exception e) {
                         exceptionInConsumerThread.set(e);
-                        break;
                     }
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);


### PR DESCRIPTION
由于队列阻塞导致线程死锁问题的发生.在消费过程中,若出现异常,不再进行消费终止,而是继续消费,避免队列阻塞.

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

